### PR TITLE
Change markdownify to safeHTML

### DIFF
--- a/layouts/shortcodes/video.html
+++ b/layouts/shortcodes/video.html
@@ -62,6 +62,6 @@
     <source src="{{ .RelPermalink }}" type="video/mp4" }}>
     {{ $video_dl = . }}
   {{ end }}
-  <p>{{ i18n "videoUnsupported" $video_dl | markdownify }}</p>
+  <p>{{ i18n "videoUnsupported" $video_dl | safeHTML}}</p>
 </video>
 {{ end }}


### PR DESCRIPTION
This makes the fallback text for browsers that don't support video
elements render in Hugo 0.60.0 and later without having to enable the
unsafe rendering option.

Hugo 0.60.0 moved from Blackfriday to Goldmark for Markdown rendering,
and Goldmark is stricter about escaping inline html in Markdown content.
https://github.com/gohugoio/hugo/releases/tag/v0.60.0